### PR TITLE
Fixed rare issue with DiffCleanupSemantic

### DIFF
--- a/diffmatchpatch/dmp.go
+++ b/diffmatchpatch/dmp.go
@@ -967,7 +967,7 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 					float64(overlap_length2) >= float64(len(insertion))/2 {
 					// Reverse overlap found.
 					// Insert an equality and swap and trim the surrounding edits.
-					overlap := Diff{DiffEqual, insertion[overlap_length2:]}
+					overlap := Diff{DiffEqual, deletion[0:overlap_length2]}
 					diffs = append(
 						diffs[:pointer],
 						append([]Diff{overlap}, diffs[pointer:]...)...)


### PR DESCRIPTION
Output was mangled for very specific phrases.
Python version produced clean output.
Go version fixed to be the same as Python version.

**Example input phrase to diff:**
text1 = "James McCarthy close to signing new Everton deal"
text2 = "James McCarthy signs new five-year deal at Everton"

**golang DiffCleanupSemantic output before fix:**

```
[{Type:0 Text:James McCarthy } {Type:-1 Text:close to } {Type:0 Text:sign} {Type:-1 Text:ing} {Type:1 Text:s} {Type:0 Text: new } {Type:1 Text:five-year deal at } {Type:0 Text:ar deal at Everton} {Type:-1 Text: deal}]
```

**python DiffCleanupSemantic output (current):**

```
[(0, 'James McCarthy '), (-1, 'close to '), (0, 'sign'), (-1, 'ing'), (1, 's'), (0, ' new '), (1, 'five-year deal at '), (0, 'Everton'), (-1, ' deal')]
```

**golang DiffCleanupSemantic output after fix:**

```
[{Type:0 Text:James McCarthy } {Type:-1 Text:close to } {Type:0 Text:sign} {Type:-1 Text:ing} {Type:1 Text:s} {Type:0 Text: new } {Type:1 Text:five-year deal at } {Type:0 Text:Everton} {Type:-1 Text: deal}]
```
