### PR TITLE
Use QueryUnescape instead of a custom unescaper

### DIFF
--- a/diffmatchpatch/dmp.go
+++ b/diffmatchpatch/dmp.go
@@ -42,21 +42,6 @@ const (
 	DiffEqual  Operation = 0
 )
 
-// unescaper unescapes selected chars for compatability with JavaScript's encodeURI.
-// In speed critical applications this could be dropped since the
-// receiving application will certainly decode these fine.
-// Note that this function is case-sensitive.  Thus "%3F" would not be
-// unescaped.  But this is ok because it is only called with the output of
-// HttpUtility.UrlEncode which returns lowercase hex.
-//
-// Example: "%3f" -> "?", "%24" -> "$", etc.
-var unescaper = strings.NewReplacer(
-	"%21", "!", "%7E", "~", "%27", "'",
-	"%28", "(", "%29", ")", "%3B", ";",
-	"%2F", "/", "%3F", "?", "%3A", ":",
-	"%40", "@", "%26", "&", "%3D", "=",
-	"%2B", "+", "%24", "$", "%2C", ",", "%23", "#", "%2A", "*")
-
 // Define some regex patterns for matching boundaries.
 var (
 	nonAlphaNumericRegex_ = regexp.MustCompile(`[^a-zA-Z0-9]`)
@@ -193,7 +178,7 @@ func (p *Patch) String() string {
 	for _, aDiff := range p.diffs {
 		switch aDiff.Type {
 		case DiffInsert:
-			text.WriteString("+")
+			text.WriteString("%2b")
 		case DiffDelete:
 			text.WriteString("-")
 		case DiffEqual:
@@ -204,7 +189,8 @@ func (p *Patch) String() string {
 		text.WriteString("\n")
 	}
 
-	return unescaper.Replace(text.String())
+	out,_ := url.QueryUnescape(text.String())
+	return out
 }
 
 type DiffMatchPatch struct {
@@ -1490,8 +1476,9 @@ func (dmp *DiffMatchPatch) DiffToDelta(diffs []Diff) string {
 	delta := text.String()
 	if len(delta) != 0 {
 		// Strip off trailing tab character.
+		var _ error
 		delta = delta[0 : utf8.RuneCountInString(delta)-1]
-		delta = unescaper.Replace(delta)
+		delta, _ = url.QueryUnescape(delta)
 	}
 	return delta
 }


### PR DESCRIPTION
The custom unescapper was missing too many items (\n -> %0A, " -> %22, % -> %25, etc)