### PR TITLE
Fixed bug in overlap elimination.

### DIFF
--- a/diffmatchpatch/dmp.go
+++ b/diffmatchpatch/dmp.go
@@ -967,7 +967,7 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 					float64(overlap_length2) >= float64(len(insertion))/2 {
 					// Reverse overlap found.
 					// Insert an equality and swap and trim the surrounding edits.
-					overlap := Diff{DiffEqual, insertion[overlap_length2:]}
+					overlap := Diff{DiffEqual, insertion[len(insertion)-overlap_length2:]}
 					diffs = append(
 						diffs[:pointer],
 						append([]Diff{overlap}, diffs[pointer:]...)...)

--- a/diffmatchpatch/dmp_test.go
+++ b/diffmatchpatch/dmp_test.go
@@ -563,6 +563,29 @@ func Test_diffCleanupSemantic(t *testing.T) {
 		Diff{DiffEqual, "1234"},
 		Diff{DiffDelete, "wxyz"}}, diffs)
 
+	// No elimination #3.
+	diffs = []Diff{
+		Diff{DiffEqual, "2016-09-01T03:07:1"},
+		Diff{DiffInsert, "5.15"},
+		Diff{DiffEqual, "4"},
+		Diff{DiffDelete, "."},
+		Diff{DiffEqual, "80"},
+		Diff{DiffInsert, "0"},
+		Diff{DiffEqual, "78"},
+		Diff{DiffDelete, "3074"},
+		Diff{DiffEqual, "1Z"}}
+	diffs = dmp.DiffCleanupSemantic(diffs)
+	assertDiffEqual(t, []Diff{
+		Diff{DiffEqual, "2016-09-01T03:07:1"},
+		Diff{DiffInsert, "5.15"},
+		Diff{DiffEqual, "4"},
+		Diff{DiffDelete, "."},
+		Diff{DiffEqual, "80"},
+		Diff{DiffInsert, "0"},
+		Diff{DiffEqual, "78"},
+		Diff{DiffDelete, "3074"},
+		Diff{DiffEqual, "1Z"}}, diffs)
+
 	// Simple elimination.
 	diffs = []Diff{
 		Diff{DiffDelete, "a"},


### PR DESCRIPTION
Fixed bug in overlap elimination which produced incorrect diffs to processed by PatchMake. Example case https://github.com/sergi/go-diff/issues/31

Added a UT as well to reflect an example use case that should have been passing.