### PR TITLE
Fixed bug in overlap elimination

### DIFF
--- a/diffmatchpatch/dmp.go
+++ b/diffmatchpatch/dmp.go
@@ -967,7 +967,7 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 					float64(overlapLength2) >= float64(len(insertion))/2 {
 					// Reverse overlap found.
 					// Insert an equality and swap and trim the surrounding edits.
-					overlap := Diff{DiffEqual, insertion[overlapLength2:]}
+					overlap := Diff{DiffEqual, insertion[len(insertion)-overlapLength2:]}
 					diffs = append(
 						diffs[:pointer],
 						append([]Diff{overlap}, diffs[pointer:]...)...)

--- a/diffmatchpatch/dmp_test.go
+++ b/diffmatchpatch/dmp_test.go
@@ -563,6 +563,29 @@ func Test_diffCleanupSemantic(t *testing.T) {
 		Diff{DiffEqual, "1234"},
 		Diff{DiffDelete, "wxyz"}}, diffs)
 
+	// No elimination #3.
+	diffs = []Diff{
+		Diff{DiffEqual, "2016-09-01T03:07:1"},
+		Diff{DiffInsert, "5.15"},
+		Diff{DiffEqual, "4"},
+		Diff{DiffDelete, "."},
+		Diff{DiffEqual, "80"},
+		Diff{DiffInsert, "0"},
+		Diff{DiffEqual, "78"},
+		Diff{DiffDelete, "3074"},
+		Diff{DiffEqual, "1Z"}}
+	diffs = dmp.DiffCleanupSemantic(diffs)
+	assertDiffEqual(t, []Diff{
+		Diff{DiffEqual, "2016-09-01T03:07:1"},
+		Diff{DiffInsert, "5.15"},
+		Diff{DiffEqual, "4"},
+		Diff{DiffDelete, "."},
+		Diff{DiffEqual, "80"},
+		Diff{DiffInsert, "0"},
+		Diff{DiffEqual, "78"},
+		Diff{DiffDelete, "3074"},
+		Diff{DiffEqual, "1Z"}}, diffs)
+
 	// Simple elimination.
 	diffs = []Diff{
 		Diff{DiffDelete, "a"},

--- a/diffmatchpatch/dmp_test.go
+++ b/diffmatchpatch/dmp_test.go
@@ -1268,6 +1268,9 @@ func Test_patch_make(t *testing.T) {
 	expectedPatch = "@@ -573,28 +573,31 @@\n cdefabcdefabcdefabcdefabcdef\n+123\n"
 	patches = dmp.PatchMake(text1, text2)
 	assert.Equal(t, expectedPatch, dmp.PatchToText(patches), "patch_make: Long string with repeats.")
+
+	patches = dmp.PatchMake("2016-09-01T03:07:14.807830741Z", "2016-09-01T03:07:15.154800781Z")
+	assert.Equal(t, "@@ -15,16 +15,16 @@\n 07:1\n+5.15\n 4\n-.\n 80\n+0\n 78\n-3074\n 1Z\n", dmp.PatchToText(patches), "patch_make: Corner case of #31 fixed by #32")
 }
 
 func Test_PatchSplitMax(t *testing.T) {


### PR DESCRIPTION
This is the rebased version of #32 with an additional test case of #31.

Closes #31, closes #32 