### PR TITLE
Remove assertMapEqual in favor of assert.Equal

### DIFF
--- a/diffmatchpatch/dmp_test.go
+++ b/diffmatchpatch/dmp_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -39,37 +38,6 @@ func pretty(diffs []Diff) string {
 		_, _ = w.WriteString(fmt.Sprintf(": %v\n", diff.Text))
 	}
 	return w.String()
-}
-
-func assertMapEqual(t *testing.T, seq1, seq2 interface{}) {
-	v1 := reflect.ValueOf(seq1)
-	k1 := v1.Kind()
-	v2 := reflect.ValueOf(seq2)
-	k2 := v2.Kind()
-
-	if k1 != reflect.Map || k2 != reflect.Map {
-		t.Fatalf("%v Parameters are not maps", caller())
-	} else if v1.Len() != v2.Len() {
-		t.Fatalf("%v Maps of different length: %v != %v", caller(), v1.Len(), v2.Len())
-	}
-
-	keys1, keys2 := v1.MapKeys(), v2.MapKeys()
-
-	if len(keys1) != len(keys2) {
-		t.Fatalf("%v Maps of different length", caller())
-	}
-
-	for _, key1 := range keys1 {
-		if a, b := v2.MapIndex(key1).Interface(), v1.MapIndex(key1).Interface(); a != b {
-			t.Fatalf("%v Different key/value in Map: %v != %v", caller(), a, b)
-		}
-	}
-
-	for _, key2 := range keys2 {
-		if a, b := v1.MapIndex(key2).Interface(), v2.MapIndex(key2).Interface(); a != b {
-			t.Fatalf("%v Different key/value in Map: %v != %v", caller(), a, b)
-		}
-	}
 }
 
 func assertDiffEqual(t *testing.T, seq1, seq2 []Diff) {
@@ -1067,20 +1035,20 @@ func Test_diffMain(t *testing.T) {
 
 func Test_match_alphabet(t *testing.T) {
 	dmp := New()
-	// Initialise the bitmasks for Bitap.
+
 	bitmask := map[byte]int{
 		'a': 4,
 		'b': 2,
 		'c': 1,
 	}
-	assertMapEqual(t, bitmask, dmp.MatchAlphabet("abc"))
+	assert.Equal(t, bitmask, dmp.MatchAlphabet("abc"))
 
 	bitmask = map[byte]int{
 		'a': 37,
 		'b': 18,
 		'c': 8,
 	}
-	assertMapEqual(t, bitmask, dmp.MatchAlphabet("abcaba"))
+	assert.Equal(t, bitmask, dmp.MatchAlphabet("abcaba"))
 }
 
 func Test_match_bitap(t *testing.T) {


### PR DESCRIPTION
assert.Equal does of testify/assert does already handle maps. One might
say that assertMapEqual has nicer error messages but that is something
that could be improved for assert.Equal.

This PR obsoletes #18 