### PR TITLE
Assorted optimizations

### DIFF
--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -435,29 +435,28 @@ func (dmp *DiffMatchPatch) DiffCommonSuffix(text1, text2 string) int {
 // commonPrefixLength returns the length of the common prefix of two rune slices.
 func commonPrefixLength(text1, text2 []rune) int {
 	// Linear search. See comment in commonSuffixLength.
-	short, long := text1, text2
-	if len(short) > len(long) {
-		short, long = long, short
-	}
-	for i, r := range short {
-		if r != long[i] {
-			return i
+	n := 0
+	for ; n < len(text1) && n < len(text2); n++ {
+		if text1[n] != text2[n] {
+			return n
 		}
 	}
-	return len(short)
+	return n
 }
 
 // commonSuffixLength returns the length of the common suffix of two rune slices.
 func commonSuffixLength(text1, text2 []rune) int {
 	// Use linear search rather than the binary search discussed at https://neil.fraser.name/news/2007/10/09/.
 	// See discussion at https://github.com/sergi/go-diff/issues/54.
-	n := min(len(text1), len(text2))
-	for i := 0; i < n; i++ {
-		if text1[len(text1)-i-1] != text2[len(text2)-i-1] {
-			return i
+	i1 := len(text1)
+	i2 := len(text2)
+	for n := 0; ; n++ {
+		i1--
+		i2--
+		if i1 < 0 || i2 < 0 || text1[i1] != text2[i2] {
+			return n
 		}
 	}
-	return n
 }
 
 // DiffCommonOverlap determines if the suffix of one string is the prefix of another.

--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -283,7 +283,7 @@ func (dmp *DiffMatchPatch) diffBisect(runes1, runes2 []rune, deadline time.Time)
 	k2end := 0
 	for d := 0; d < maxD; d++ {
 		// Bail out if deadline is reached.
-		if !deadline.IsZero() && time.Now().After(deadline) {
+		if !deadline.IsZero() && d%16 == 0 && time.Now().After(deadline) {
 			break
 		}
 

--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -434,6 +434,7 @@ func (dmp *DiffMatchPatch) DiffCommonSuffix(text1, text2 string) int {
 
 // commonPrefixLength returns the length of the common prefix of two rune slices.
 func commonPrefixLength(text1, text2 []rune) int {
+	// Linear search. See comment in commonSuffixLength.
 	short, long := text1, text2
 	if len(short) > len(long) {
 		short, long = long, short
@@ -448,6 +449,8 @@ func commonPrefixLength(text1, text2 []rune) int {
 
 // commonSuffixLength returns the length of the common suffix of two rune slices.
 func commonSuffixLength(text1, text2 []rune) int {
+	// Use linear search rather than the binary search discussed at https://neil.fraser.name/news/2007/10/09/.
+	// See discussion at https://github.com/sergi/go-diff/issues/54.
 	n := min(len(text1), len(text2))
 	for i := 0; i < n; i++ {
 		if text1[len(text1)-i-1] != text2[len(text2)-i-1] {
@@ -455,27 +458,6 @@ func commonSuffixLength(text1, text2 []rune) int {
 		}
 	}
 	return n
-
-	// TODO research and benchmark this, why is it not activated? https://github.com/sergi/go-diff/issues/54
-	// Binary search.
-	// Performance analysis: http://neil.fraser.name/news/2007/10/09/
-	/*
-	   pointermin := 0
-	   pointermax := math.Min(len(text1), len(text2))
-	   pointermid := pointermax
-	   pointerend := 0
-	   for pointermin < pointermid {
-	       if text1[len(text1)-pointermid:len(text1)-pointerend] ==
-	           text2[len(text2)-pointermid:len(text2)-pointerend] {
-	           pointermin = pointermid
-	           pointerend = pointermin
-	       } else {
-	           pointermax = pointermid
-	       }
-	       pointermid = math.Floor((pointermax-pointermin)/2 + pointermin)
-	   }
-	   return pointermid
-	*/
 }
 
 // DiffCommonOverlap determines if the suffix of one string is the prefix of another.

--- a/diffmatchpatch/diff_test.go
+++ b/diffmatchpatch/diff_test.go
@@ -130,6 +130,8 @@ func TestDiffCommonSuffix(t *testing.T) {
 	}
 }
 
+var SinkInt int // exported sink var to avoid compiler optimizations in benchmarks
+
 func BenchmarkDiffCommonSuffix(b *testing.B) {
 	s := "ABCDEFGHIJKLMNOPQRSTUVWXYZÅÄÖ"
 
@@ -138,8 +140,40 @@ func BenchmarkDiffCommonSuffix(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		dmp.DiffCommonSuffix(s, s)
+		SinkInt = dmp.DiffCommonSuffix(s, s)
 	}
+}
+
+func BenchmarkCommonLength(b *testing.B) {
+	data := []struct {
+		name string
+		x, y []rune
+	}{
+		{name: "empty", x: nil, y: []rune{}},
+		{name: "short", x: []rune("AABCC"), y: []rune("AA-CC")},
+		{name: "long",
+			x: []rune(strings.Repeat("A", 1000) + "B" + strings.Repeat("C", 1000)),
+			y: []rune(strings.Repeat("A", 1000) + "-" + strings.Repeat("C", 1000)),
+		},
+	}
+	b.Run("prefix", func(b *testing.B) {
+		for _, d := range data {
+			b.Run(d.name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					SinkInt = commonPrefixLength(d.x, d.y)
+				}
+			})
+		}
+	})
+	b.Run("suffix", func(b *testing.B) {
+		for _, d := range data {
+			b.Run(d.name, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					SinkInt = commonSuffixLength(d.x, d.y)
+				}
+			})
+		}
+	})
 }
 
 func TestCommonSuffixLength(t *testing.T) {


### PR DESCRIPTION
Overall performance impact from this PR:

```
name                         old time/op    new time/op    delta
DiffCommonPrefix-8              147ns ± 1%     146ns ± 1%   -0.59%  (p=0.037 n=8+8)
DiffCommonSuffix-8              161ns ± 1%     155ns ± 1%   -3.23%  (p=0.000 n=9+8)
CommonLength/prefix/empty-8    4.08ns ± 2%    3.77ns ± 1%   -7.80%  (p=0.000 n=9+10)
CommonLength/prefix/short-8    5.29ns ± 2%    5.01ns ± 1%   -5.30%  (p=0.000 n=10+9)
CommonLength/prefix/long-8      604ns ± 2%     613ns ± 2%   +1.42%  (p=0.005 n=10+10)
CommonLength/suffix/empty-8    3.82ns ± 1%    3.68ns ± 1%   -3.82%  (p=0.000 n=10+10)
CommonLength/suffix/short-8    6.36ns ± 1%    5.90ns ± 1%   -7.15%  (p=0.000 n=9+10)
CommonLength/suffix/long-8     1.13µs ± 1%    0.91µs ± 1%  -19.72%  (p=0.000 n=9+10)
DiffHalfMatch-8                 107µs ± 1%     108µs ± 0%   +0.70%  (p=0.000 n=10+10)
DiffCleanupSemantic-8          11.7ms ± 2%     0.9ms ± 1%  -92.15%  (p=0.000 n=10+10)
DiffMain-8                      1.01s ± 0%     1.01s ± 0%   +0.19%  (p=0.000 n=9+9)
DiffMainLarge-8                 138ms ± 1%     102ms ± 2%  -26.20%  (p=0.000 n=8+10)
DiffMainRunesLargeLines-8       721µs ± 1%     515µs ± 1%  -28.56%  (p=0.000 n=9+10)

name                         old alloc/op   new alloc/op   delta
DiffCommonPrefix-8              0.00B          0.00B          ~     (all equal)
DiffCommonSuffix-8              0.00B          0.00B          ~     (all equal)
CommonLength/prefix/empty-8     0.00B          0.00B          ~     (all equal)
CommonLength/prefix/short-8     0.00B          0.00B          ~     (all equal)
CommonLength/prefix/long-8      0.00B          0.00B          ~     (all equal)
CommonLength/suffix/empty-8     0.00B          0.00B          ~     (all equal)
CommonLength/suffix/short-8     0.00B          0.00B          ~     (all equal)
CommonLength/suffix/long-8      0.00B          0.00B          ~     (all equal)
DiffHalfMatch-8                 106kB ± 0%     106kB ± 0%     ~     (all equal)
DiffCleanupSemantic-8          17.7MB ± 0%     0.2MB ± 0%  -99.08%  (p=0.000 n=6+9)
DiffMain-8                     16.4MB ± 0%    16.4MB ± 0%   -0.00%  (p=0.000 n=10+10)
DiffMainLarge-8                63.8MB ± 0%     4.8MB ± 0%  -92.46%  (p=0.000 n=10+7)
DiffMainRunesLargeLines-8       209kB ± 0%     174kB ± 0%  -16.82%  (p=0.000 n=10+10)

name                         old allocs/op  new allocs/op  delta
DiffCommonPrefix-8               0.00           0.00          ~     (all equal)
DiffCommonSuffix-8               0.00           0.00          ~     (all equal)
CommonLength/prefix/empty-8      0.00           0.00          ~     (all equal)
CommonLength/prefix/short-8      0.00           0.00          ~     (all equal)
CommonLength/prefix/long-8       0.00           0.00          ~     (all equal)
CommonLength/suffix/empty-8      0.00           0.00          ~     (all equal)
CommonLength/suffix/short-8      0.00           0.00          ~     (all equal)
CommonLength/suffix/long-8       0.00           0.00          ~     (all equal)
DiffHalfMatch-8                  2.00 ± 0%      2.00 ± 0%     ~     (all equal)
DiffCleanupSemantic-8           11.4k ± 0%      1.1k ± 0%  -90.22%  (p=0.000 n=10+10)
DiffMain-8                       89.0 ± 0%      84.0 ± 0%   -5.62%  (p=0.000 n=10+10)
DiffMainLarge-8                 55.3k ± 0%     46.3k ± 0%  -16.35%  (p=0.000 n=10+8)
DiffMainRunesLargeLines-8       1.19k ± 0%     1.08k ± 0%   -9.33%  (p=0.001 n=8+9)
```

There's still some fairly low hanging fruit remaining after this, but I'm out of time for the moment. Hopefully this is enough of an impact nevertheless to attract a reviewer.

Please note that I may be slow (like days or weeks) to respond to review comments, particularly if they are substantive.

This PR is designed to be read and reviewed commit-by-commit.

cc @maksimov @zimmski
