### PR TITLE
fix DiffCleanupSemantic

### DIFF
--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -739,8 +739,8 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 					pointer++
 				}
 			} else {
-				if float64(overlapLength2) >= float64(len(deletion))/2 ||
-					float64(overlapLength2) >= float64(len(insertion))/2 {
+				if float64(overlapLength2) >= float64(len([]rune(deletion)))/2 ||
+					float64(overlapLength2) >= float64(len([]rune(insertion)))/2 {
 					// Reverse overlap found. Insert an equality and swap and trim the surrounding edits.
 					overlap := Diff{DiffEqual, deletion[:overlapLength2]}
 					diffs = splice(diffs, pointer, 0, overlap)

--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -500,8 +500,8 @@ func commonSuffixLength(text1, text2 []rune) int {
 // DiffCommonOverlap determines if the suffix of one string is the prefix of another.
 func (dmp *DiffMatchPatch) DiffCommonOverlap(text1 string, text2 string) int {
 	// Cache the text lengths to prevent multiple calls.
-	text1Length := len(text1)
-	text2Length := len(text2)
+	text1Length := len([]rune(text1))
+	text2Length := len([]rune(text2))
 	// Eliminate the null case.
 	if text1Length == 0 || text2Length == 0 {
 		return 0

--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -500,8 +500,8 @@ func commonSuffixLength(text1, text2 []rune) int {
 // DiffCommonOverlap determines if the suffix of one string is the prefix of another.
 func (dmp *DiffMatchPatch) DiffCommonOverlap(text1 string, text2 string) int {
 	// Cache the text lengths to prevent multiple calls.
-	text1Length := len([]rune(text1))
-	text2Length := len([]rune(text2))
+	text1Length := len(text1)
+	text2Length := len(text2)
 	// Eliminate the null case.
 	if text1Length == 0 || text2Length == 0 {
 		return 0

--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -670,16 +670,16 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 			// An insertion or deletion.
 
 			if diffs[pointer].Type == DiffInsert {
-				lengthInsertions2 += len([]rune(diffs[pointer].Text))
+				lengthInsertions2 += utf8.RuneCountInString(diffs[pointer].Text)
 			} else {
-				lengthDeletions2 += len([]rune(diffs[pointer].Text))
+				lengthDeletions2 += utf8.RuneCountInString(diffs[pointer].Text)
 			}
 			// Eliminate an equality that is smaller or equal to the edits on both sides of it.
 			difference1 := int(math.Max(float64(lengthInsertions1), float64(lengthDeletions1)))
 			difference2 := int(math.Max(float64(lengthInsertions2), float64(lengthDeletions2)))
-			if len([]rune(lastequality)) > 0 &&
-				(len([]rune(lastequality)) <= difference1) &&
-				(len([]rune(lastequality)) <= difference2) {
+			if utf8.RuneCountInString(lastequality) > 0 &&
+				(utf8.RuneCountInString(lastequality) <= difference1) &&
+				(utf8.RuneCountInString(lastequality) <= difference2) {
 				// Duplicate record.
 				insPoint := equalities[len(equalities)-1]
 				diffs = splice(diffs, insPoint, 0, Diff{DiffDelete, lastequality})
@@ -728,8 +728,8 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 			overlapLength1 := dmp.DiffCommonOverlap(deletion, insertion)
 			overlapLength2 := dmp.DiffCommonOverlap(insertion, deletion)
 			if overlapLength1 >= overlapLength2 {
-				if float64(overlapLength1) >= float64(len([]rune(deletion)))/2 ||
-					float64(overlapLength1) >= float64(len([]rune(insertion)))/2 {
+				if float64(overlapLength1) >= float64(utf8.RuneCountInString(deletion))/2 ||
+					float64(overlapLength1) >= float64(utf8.RuneCountInString(insertion))/2 {
 
 					// Overlap found. Insert an equality and trim the surrounding edits.
 					diffs = splice(diffs, pointer, 0, Diff{DiffEqual, insertion[:overlapLength1]})
@@ -739,8 +739,8 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 					pointer++
 				}
 			} else {
-				if float64(overlapLength2) >= float64(len([]rune(deletion)))/2 ||
-					float64(overlapLength2) >= float64(len([]rune(insertion)))/2 {
+				if float64(overlapLength2) >= float64(utf8.RuneCountInString(deletion))/2 ||
+					float64(overlapLength2) >= float64(utf8.RuneCountInString(insertion))/2 {
 					// Reverse overlap found. Insert an equality and swap and trim the surrounding edits.
 					overlap := Diff{DiffEqual, deletion[:overlapLength2]}
 					diffs = splice(diffs, pointer, 0, overlap)

--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -728,24 +728,24 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 			overlapLength1 := dmp.DiffCommonOverlap(deletion, insertion)
 			overlapLength2 := dmp.DiffCommonOverlap(insertion, deletion)
 			if overlapLength1 >= overlapLength2 {
-				if float64(overlapLength1) >= float64(len([]rune(deletion)))/2 ||
-					float64(overlapLength1) >= float64(len([]rune(insertion)))/2 {
+				if float64(overlapLength1) >= float64(len(deletion))/2 ||
+					float64(overlapLength1) >= float64(len(insertion))/2 {
 
 					// Overlap found. Insert an equality and trim the surrounding edits.
 					diffs = splice(diffs, pointer, 0, Diff{DiffEqual, insertion[:overlapLength1]})
 					diffs[pointer-1].Text =
-						deletion[0 : len([]rune(deletion))-overlapLength1]
+						deletion[0 : len(deletion)-overlapLength1]
 					diffs[pointer+1].Text = insertion[overlapLength1:]
 					pointer++
 				}
 			} else {
-				if float64(overlapLength2) >= float64(len([]rune(deletion)))/2 ||
-					float64(overlapLength2) >= float64(len([]rune(insertion)))/2 {
+				if float64(overlapLength2) >= float64(len(deletion))/2 ||
+					float64(overlapLength2) >= float64(len(insertion))/2 {
 					// Reverse overlap found. Insert an equality and swap and trim the surrounding edits.
 					overlap := Diff{DiffEqual, deletion[:overlapLength2]}
 					diffs = splice(diffs, pointer, 0, overlap)
 					diffs[pointer-1].Type = DiffInsert
-					diffs[pointer-1].Text = insertion[0 : len([]rune(insertion))-overlapLength2]
+					diffs[pointer-1].Text = insertion[0 : len(insertion)-overlapLength2]
 					diffs[pointer+1].Type = DiffDelete
 					diffs[pointer+1].Text = deletion[overlapLength2:]
 					pointer++

--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -670,16 +670,16 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 			// An insertion or deletion.
 
 			if diffs[pointer].Type == DiffInsert {
-				lengthInsertions2 += len(diffs[pointer].Text)
+				lengthInsertions2 += len([]rune(diffs[pointer].Text))
 			} else {
-				lengthDeletions2 += len(diffs[pointer].Text)
+				lengthDeletions2 += len([]rune(diffs[pointer].Text))
 			}
 			// Eliminate an equality that is smaller or equal to the edits on both sides of it.
 			difference1 := int(math.Max(float64(lengthInsertions1), float64(lengthDeletions1)))
 			difference2 := int(math.Max(float64(lengthInsertions2), float64(lengthDeletions2)))
-			if len(lastequality) > 0 &&
-				(len(lastequality) <= difference1) &&
-				(len(lastequality) <= difference2) {
+			if len([]rune(lastequality)) > 0 &&
+				(len([]rune(lastequality)) <= difference1) &&
+				(len([]rune(lastequality)) <= difference2) {
 				// Duplicate record.
 				insPoint := equalities[len(equalities)-1]
 				diffs = splice(diffs, insPoint, 0, Diff{DiffDelete, lastequality})
@@ -728,24 +728,24 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 			overlapLength1 := dmp.DiffCommonOverlap(deletion, insertion)
 			overlapLength2 := dmp.DiffCommonOverlap(insertion, deletion)
 			if overlapLength1 >= overlapLength2 {
-				if float64(overlapLength1) >= float64(len(deletion))/2 ||
-					float64(overlapLength1) >= float64(len(insertion))/2 {
+				if float64(overlapLength1) >= float64(len([]rune(deletion)))/2 ||
+					float64(overlapLength1) >= float64(len([]rune(insertion)))/2 {
 
 					// Overlap found. Insert an equality and trim the surrounding edits.
 					diffs = splice(diffs, pointer, 0, Diff{DiffEqual, insertion[:overlapLength1]})
 					diffs[pointer-1].Text =
-						deletion[0 : len(deletion)-overlapLength1]
+						deletion[0 : len([]rune(deletion))-overlapLength1]
 					diffs[pointer+1].Text = insertion[overlapLength1:]
 					pointer++
 				}
 			} else {
-				if float64(overlapLength2) >= float64(len(deletion))/2 ||
-					float64(overlapLength2) >= float64(len(insertion))/2 {
+				if float64(overlapLength2) >= float64(len([]rune(deletion)))/2 ||
+					float64(overlapLength2) >= float64(len([]rune(insertion)))/2 {
 					// Reverse overlap found. Insert an equality and swap and trim the surrounding edits.
 					overlap := Diff{DiffEqual, deletion[:overlapLength2]}
 					diffs = splice(diffs, pointer, 0, overlap)
 					diffs[pointer-1].Type = DiffInsert
-					diffs[pointer-1].Text = insertion[0 : len(insertion)-overlapLength2]
+					diffs[pointer-1].Text = insertion[0 : len([]rune(insertion))-overlapLength2]
 					diffs[pointer+1].Type = DiffDelete
 					diffs[pointer+1].Text = deletion[overlapLength2:]
 					pointer++

--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -728,8 +728,8 @@ func (dmp *DiffMatchPatch) DiffCleanupSemantic(diffs []Diff) []Diff {
 			overlapLength1 := dmp.DiffCommonOverlap(deletion, insertion)
 			overlapLength2 := dmp.DiffCommonOverlap(insertion, deletion)
 			if overlapLength1 >= overlapLength2 {
-				if float64(overlapLength1) >= float64(len(deletion))/2 ||
-					float64(overlapLength1) >= float64(len(insertion))/2 {
+				if float64(overlapLength1) >= float64(len([]rune(deletion)))/2 ||
+					float64(overlapLength1) >= float64(len([]rune(insertion)))/2 {
 
 					// Overlap found. Insert an equality and trim the surrounding edits.
 					diffs = splice(diffs, pointer, 0, Diff{DiffEqual, insertion[:overlapLength1]})

--- a/diffmatchpatch/diff_test.go
+++ b/diffmatchpatch/diff_test.go
@@ -845,6 +845,18 @@ func TestDiffCleanupSemantic(t *testing.T) {
 				{DiffInsert, "a new hope"},
 			},
 		},
+		{
+			"panic",
+			[]Diff{
+				{DiffInsert, "킬러 인 "},
+				{DiffEqual, "리커버리"},
+				{DiffDelete, " 보이즈"},
+			},
+			[]Diff{
+				{DiffDelete, "리커버리 보이즈"},
+				{DiffInsert, "킬러 인 리커버리"},
+			},
+		},
 	} {
 		actual := dmp.DiffCleanupSemantic(tc.Diffs)
 		assert.Equal(t, tc.Expected, actual, fmt.Sprintf("Test case #%d, %s", i, tc.Name))

--- a/diffmatchpatch/diff_test.go
+++ b/diffmatchpatch/diff_test.go
@@ -853,8 +853,9 @@ func TestDiffCleanupSemantic(t *testing.T) {
 				{DiffDelete, " 보이즈"},
 			},
 			[]Diff{
-				{DiffDelete, "리커버리 보이즈"},
-				{DiffInsert, "킬러 인 리커버리"},
+				{DiffInsert, "킬러 인 "},
+				{DiffEqual, "리커버리"},
+				{DiffDelete, " 보이즈"},
 			},
 		},
 	} {

--- a/diffmatchpatch/diff_test.go
+++ b/diffmatchpatch/diff_test.go
@@ -821,6 +821,30 @@ func TestDiffCleanupSemantic(t *testing.T) {
 				{DiffDelete, " deal"},
 			},
 		},
+		{
+			"Taken from python / CPP library",
+			[]Diff{
+				{DiffInsert, "星球大戰：新的希望 "},
+				{DiffEqual, "star wars: "},
+				{DiffDelete, "episodio iv - un"},
+				{DiffEqual, "a n"},
+				{DiffDelete, "u"},
+				{DiffEqual, "e"},
+				{DiffDelete, "va"},
+				{DiffInsert, "w"},
+				{DiffEqual, " "},
+				{DiffDelete, "es"},
+				{DiffInsert, "ho"},
+				{DiffEqual, "pe"},
+				{DiffDelete, "ranza"},
+			},
+			[]Diff{
+				{DiffInsert, "星球大戰：新的希望 "},
+				{DiffEqual, "star wars: "},
+				{DiffDelete, "episodio iv - una nueva esperanza"},
+				{DiffInsert, "a new hope"},
+			},
+		},
 	} {
 		actual := dmp.DiffCleanupSemantic(tc.Diffs)
 		assert.Equal(t, tc.Expected, actual, fmt.Sprintf("Test case #%d, %s", i, tc.Name))


### PR DESCRIPTION
currently, DiffCleanupSemantic only works for Ascii chars. In our company we've got Chinese chars as well, so the DiffCleanupSemantic does not work there since len("新") != len([]rune("新")).

See: https://play.golang.org/p/oTXcxo0gH1R

The [Python lib](https://github.com/diff-match-patch-python/diff-match-patch) has the same behaviour like the fixed version.

