### PR TITLE
Made diffprettytext replace invisibles with unicode characters

### DIFF
--- a/diffmatchpatch/diff.go
+++ b/diffmatchpatch/diff.go
@@ -1152,10 +1152,14 @@ func (dmp *DiffMatchPatch) DiffPrettyText(diffs []Diff) string {
 		switch diff.Type {
 		case DiffInsert:
 			_, _ = buff.WriteString("\x1b[32m")
+			text = strings.ReplaceAll(text, " ", "█")
+			text = strings.ReplaceAll(text, "\n", "⏎")
 			_, _ = buff.WriteString(text)
 			_, _ = buff.WriteString("\x1b[0m")
 		case DiffDelete:
 			_, _ = buff.WriteString("\x1b[31m")
+			text = strings.ReplaceAll(text, " ", "█")
+			text = strings.ReplaceAll(text, "\n", "⏎")
 			_, _ = buff.WriteString(text)
 			_, _ = buff.WriteString("\x1b[0m")
 		case DiffEqual:


### PR DESCRIPTION
Not sure is this is the best method to do this, but this PR replaces invisible characters in the `Insert/Delete` diffs, so that these characters can be seen and fixed, instead of not being able to tell between diffs that look the same but have unequal whitespace, which is something that I have been struggling with.

The ways that I can see to implement this are:
* Add this functionality into the main `DiffPrettyText` function, where all spaces are converted into the Unicode Full Block character, and returns are replaced by the Unicode return symbol. (This PR)
* Create an additional pretty print function that takes does similar steps (Seems to duplicate functionality, but could potentially be the easiest)
* Modify the original function's API to add an additional boolean parameter for the function that can toggle this behavior. Out of all, this seems the most unlikely, as it would break pre-existing implementations.