### PR TITLE
Add PatchMakeRunes that uses runes to calculate string length

### DIFF
--- a/diffmatchpatch/stringutil.go
+++ b/diffmatchpatch/stringutil.go
@@ -88,6 +88,16 @@ func runesIndex(r1, r2 []rune) int {
 	return -1
 }
 
+// runesLastIndex is the equivalent of strings.LastIndex for rune slices.
+func runesLastIndex(r1, r2 []rune) int {
+	for i := len(r1) - len(r2); i >= 0; i-- {
+		if runesEqual(r1[i:i+len(r2)], r2) {
+			return i
+		}
+	}
+	return -1
+}
+
 func intArrayToString(ns []uint32) string {
 	if len(ns) == 0 {
 		return ""


### PR DESCRIPTION
Some diff libraries use unicode to calculate the string length, such as https://github.com/google/diff-match-patch, but this project uses byte, so I add a new function to complete it.