### PR TITLE
fix: use indivisible line hashes

### DIFF
--- a/diffmatchpatch/stringutil.go
+++ b/diffmatchpatch/stringutil.go
@@ -9,7 +9,6 @@
 package diffmatchpatch
 
 import (
-	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -86,21 +85,4 @@ func runesIndex(r1, r2 []rune) int {
 		}
 	}
 	return -1
-}
-
-func intArrayToString(ns []uint32) string {
-	if len(ns) == 0 {
-		return ""
-	}
-
-	indexSeparator := IndexSeparator[0]
-
-	// Appr. 3 chars per num plus the comma.
-	b := []byte{}
-	for _, n := range ns {
-		b = strconv.AppendInt(b, int64(n), 10)
-		b = append(b, indexSeparator)
-	}
-	b = b[:len(b)-1]
-	return string(b)
 }


### PR DESCRIPTION
Revert implementation of diffLines to use runes to fix #140.  In order to not regress #89, skip invalid utf8 runes when munging lines.  We also panic if we reach the upper limit.

I'm sending this out with the limitation in place and commented because I think having a limit is preferable to silently returning incorrect results as in #140.  However, the most preferable solution would be something as described in https://github.com/sergi/go-diff/issues/89#issuecomment-591376325.