### PR TITLE
Make diffs field in patch public

### DIFF
--- a/diffmatchpatch/patch_test.go
+++ b/diffmatchpatch/patch_test.go
@@ -31,7 +31,7 @@ func TestPatchString(t *testing.T) {
 				Length1: 18,
 				Length2: 17,
 
-				diffs: []Diff{
+				Diffs: []Diff{
 					{DiffEqual, "jump"},
 					{DiffDelete, "s"},
 					{DiffInsert, "ed"},
@@ -94,7 +94,7 @@ func TestPatchFromText(t *testing.T) {
 	patches, err := dmp.PatchFromText("@@ -1,21 +1,21 @@\n-%601234567890-=%5B%5D%5C;',./\n+~!@#$%25%5E&*()_+%7B%7D%7C:%22%3C%3E?\n")
 	assert.Len(t, patches, 1)
 	assert.Equal(t, diffs,
-		patches[0].diffs,
+		patches[0].Diffs,
 	)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
This is a repeat of #94 which is now ~6 years out of date, built from head.

Justification from that PR:

> Looks like the c++ and java versions of diff google-diff-match-patch have it as a public field and would be useful info to have (i.e. filter diffs of a patch by operation)

Would greatly appreciate if this PR could be merged!